### PR TITLE
Step 5 - Make view simpler

### DIFF
--- a/src/scss/_badge.scss
+++ b/src/scss/_badge.scss
@@ -1,7 +1,8 @@
 .badge {
   display: inline-block;
-  color: #E08000;
-  border: 1px solid #E08000;
+  color: $color-green;
+  background-color: $color-white;
+  border: 1px solid $color-lightgray;
   border-radius: 0.25em;
-  padding: 0.125em 0.25em;
+  padding: 0.25em 0.5em;
 }

--- a/src/ts/component/controller/_controller.ts
+++ b/src/ts/component/controller/_controller.ts
@@ -31,8 +31,8 @@ export default class Controller {
     this.deleteListeners.forEach(listener => listener(this))
   }
 
-  setWrapper(wrapper: HTMLElement) {
-    this.view.render(wrapper)
+  setWrapper(wrapper: HTMLElement, index?: number) {
+    this.view.render(wrapper, index)
   }
 
   bindMethods(methods: Array<string>) {

--- a/src/ts/component/controller/_controller.ts
+++ b/src/ts/component/controller/_controller.ts
@@ -1,10 +1,18 @@
+import View from "../view/_view"
+
 export default class Controller {
   private updateListeners: Array<Function>
   private deleteListeners: Array<Function>
+  protected id: string
+  protected view: View
 
   constructor() {
     this.updateListeners = []
     this.deleteListeners = []
+  }
+
+  getID() {
+    return this.id
   }
 
   addUpdateListener(listener: Function) {
@@ -21,5 +29,15 @@ export default class Controller {
 
   protected notifyDelete() {
     this.deleteListeners.forEach(listener => listener(this))
+  }
+
+  setWrapper(wrapper: HTMLElement) {
+    this.view.render(wrapper)
+  }
+
+  bindMethods(methods: Array<string>) {
+    methods.forEach(method => {
+      (this.view as any)[method] = (this as any)[method].bind(this)
+    })
   }
 }

--- a/src/ts/component/controller/column.ts
+++ b/src/ts/component/controller/column.ts
@@ -6,14 +6,23 @@ import NoteData from '../../type/note'
 
 export default class ColumnController extends Controller {
   private columnData: ColumnData
-  private view: ColumnView
 
-  constructor({ id, columnData }: { id: String, columnData: ColumnData }) {
+  constructor({ id, columnData }: { id: string, columnData: ColumnData }) {
     super()
+    this.id = id
     this.columnData = columnData
-    this.view = new ColumnView({ id, columnData })
-    this.view.addNote = this.addNote.bind(this)
-    this.view.removeSelf = this.removeSelf.bind(this)
+    this.view = new ColumnView()
+    this.bindMethods([
+      'getID',
+      'getData',
+      'addNote',
+      'removeSelf',
+    ])
+    this.view.render()
+  }
+
+  getData() {
+    return this.columnData
   }
 
   updateSelf(title: String) {
@@ -45,9 +54,5 @@ export default class ColumnController extends Controller {
   }
 
   removeNote(note: NoteController) {
-  }
-
-  setWrapper(wrapper: HTMLElement) {
-    this.view.render(wrapper)
   }
 }

--- a/src/ts/component/controller/column.ts
+++ b/src/ts/component/controller/column.ts
@@ -45,7 +45,11 @@ export default class ColumnController extends Controller {
   }
 
   addNote(noteData: NoteData) {
+    this.columnData.nNote++
+    this.view.render()
+
     const noteController = new NoteController({ id: '', noteData })
+    noteController.addDeleteListener(this.removeNote.bind(this))
 
     // re-render
     noteController.setWrapper(this.view.getChildrenWrapper('note'))
@@ -54,5 +58,7 @@ export default class ColumnController extends Controller {
   }
 
   removeNote(note: NoteController) {
+    this.columnData.nNote--
+    this.view.render()
   }
 }

--- a/src/ts/component/controller/column.ts
+++ b/src/ts/component/controller/column.ts
@@ -1,21 +1,25 @@
 import ColumnData from '../../type/column'
 import Controller from './_controller'
 import NoteController from './note'
-import ColumnView from '../view/column'
+import ColumnView, { ColumnRenderData } from '../view/column'
 import NoteData from '../../type/note'
 
 export default class ColumnController extends Controller {
   private columnData: ColumnData
+  private renderData: ColumnRenderData
 
   constructor({ id, columnData }: { id: string, columnData: ColumnData }) {
     super()
     this.id = id
     this.columnData = columnData
+    this.renderData = { nNote: 0, formVisible: false }
     this.view = new ColumnView()
     this.bindMethods([
       'getID',
       'getData',
+      'getRenderData',
       'addNote',
+      'toggleForm',
       'removeSelf',
     ])
     this.view.render()
@@ -23,6 +27,10 @@ export default class ColumnController extends Controller {
 
   getData() {
     return this.columnData
+  }
+
+  getRenderData() {
+    return this.renderData
   }
 
   updateSelf(title: string) {
@@ -45,7 +53,7 @@ export default class ColumnController extends Controller {
   }
 
   addNote(noteData: NoteData) {
-    this.columnData.nNote++
+    this.renderData.nNote++
     this.view.render()
 
     const noteController = new NoteController({ id: '', noteData })
@@ -58,7 +66,12 @@ export default class ColumnController extends Controller {
   }
 
   removeNote(note: NoteController) {
-    this.columnData.nNote--
+    this.renderData.nNote--
+    this.view.render()
+  }
+
+  toggleForm() {
+    this.renderData.formVisible = !this.renderData.formVisible
     this.view.render()
   }
 }

--- a/src/ts/component/controller/column.ts
+++ b/src/ts/component/controller/column.ts
@@ -25,7 +25,7 @@ export default class ColumnController extends Controller {
     return this.columnData
   }
 
-  updateSelf(title: String) {
+  updateSelf(title: string) {
     // TODO: request to server
 
     // TODO: update value

--- a/src/ts/component/controller/column.ts
+++ b/src/ts/component/controller/column.ts
@@ -51,8 +51,8 @@ export default class ColumnController extends Controller {
     const noteController = new NoteController({ id: '', noteData })
     noteController.addDeleteListener(this.removeNote.bind(this))
 
-    // re-render
-    noteController.setWrapper(this.view.getChildrenWrapper('note'))
+    // prepend note to the column
+    noteController.setWrapper(this.view.getChildrenWrapper('note'), 0)
 
     return noteController
   }

--- a/src/ts/component/controller/kanban.ts
+++ b/src/ts/component/controller/kanban.ts
@@ -6,29 +6,30 @@ import ColumnData from '../../type/column'
 
 export default class KanbanController extends Controller {
   private kanbanData: KanbanData
-  private view: KanbanView
 
-  constructor({ id, kanbanData }: { id: String, kanbanData: KanbanData }) {
+  constructor({ id, kanbanData }: { id: string, kanbanData: KanbanData }) {
     super()
+    this.id = id
     this.kanbanData = kanbanData
-    this.view = new KanbanView({ id, kanbanData })
-    this.view.addColumn = this.addColumnWithData.bind(this)
+    this.view = new KanbanView()
+    this.bindMethods([
+      'getID',
+      'getData',
+      'addColumn',
+    ])
+    this.view.render()
   }
 
-  addColumn() {
-    // TODO: open modal
+  getData() {
+    return this.kanbanData
   }
 
-  addColumnWithData(columnData: ColumnData = { title: 'new column' }) {
+  addColumn(columnData: ColumnData = { title: 'new column' }) {
     const columnController = new ColumnController({ id: '', columnData })
 
     // re-render
     columnController.setWrapper(this.view.getChildrenWrapper('column'))
 
     return columnController
-  }
-
-  setWrapper(wrapper: HTMLElement) {
-    this.view.render(wrapper)
   }
 }

--- a/src/ts/component/controller/kanban.ts
+++ b/src/ts/component/controller/kanban.ts
@@ -24,7 +24,7 @@ export default class KanbanController extends Controller {
     return this.kanbanData
   }
 
-  addColumn(columnData: ColumnData = { title: 'new column' }) {
+  addColumn(columnData: ColumnData = { title: 'new column', nNote: 0 }) {
     const columnController = new ColumnController({ id: '', columnData })
 
     // re-render

--- a/src/ts/component/controller/kanban.ts
+++ b/src/ts/component/controller/kanban.ts
@@ -24,7 +24,7 @@ export default class KanbanController extends Controller {
     return this.kanbanData
   }
 
-  addColumn(columnData: ColumnData = { title: 'new column', nNote: 0 }) {
+  addColumn(columnData: ColumnData = { title: 'new column' }) {
     const columnController = new ColumnController({ id: '', columnData })
 
     // re-render

--- a/src/ts/component/controller/note.ts
+++ b/src/ts/component/controller/note.ts
@@ -4,13 +4,22 @@ import NoteView from '../view/note'
 
 export default class NoteController extends Controller {
   private noteData: NoteData
-  private view: NoteView
 
-  constructor({ id, noteData }: { id: String, noteData: NoteData }) {
+  constructor({ id, noteData }: { id: string, noteData: NoteData }) {
     super()
+    this.id = id
     this.noteData = noteData
-    this.view = new NoteView({ id, noteData })
-    this.view.removeSelf = this.removeSelf.bind(this)
+    this.view = new NoteView()
+    this.bindMethods([
+      'getID',
+      'getData',
+      'removeSelf',
+    ])
+    this.view.render()
+  }
+
+  getData() {
+    return this.noteData
   }
 
   removeSelf() {
@@ -21,9 +30,5 @@ export default class NoteController extends Controller {
     this.view.remove()
 
     this.notifyDelete()
-  }
-
-  setWrapper(wrapper: HTMLElement) {
-    this.view.render(wrapper)
   }
 }

--- a/src/ts/component/controller/task.ts
+++ b/src/ts/component/controller/task.ts
@@ -17,7 +17,7 @@ export default class TaskController extends Controller {
     return this.taskData
   }
 
-  updateSelf(title: String) {
+  updateSelf(title: string) {
     // TODO: request to server
 
     // TODO: update value

--- a/src/ts/component/view/_view.ts
+++ b/src/ts/component/view/_view.ts
@@ -75,9 +75,19 @@ export default class View {
     return ''
   }
 
-  render(wrapper: HTMLElement = this.element.parentElement) {
-    // detach from parent
-    this.element.parentElement?.removeChild(this.element)
+  render(wrapper: HTMLElement = this.element.parentElement, index?: number) {
+    const parent = this.element.parentElement
+
+    // if parent exist
+    if (parent) {
+      // set index
+      if (index === undefined) {
+        index = Array.from(parent.children).indexOf(this.element)
+      }
+
+      // detach from parent
+      parent?.removeChild(this.element)
+    }
 
     // make new temporary element
     const newElement = document.createElement('div')
@@ -117,7 +127,7 @@ export default class View {
     // attach this to wrapper
     if (wrapper) {
       this.beforeRender()
-      wrapper.appendChild(this.element)
+      wrapper.insertBefore(this.element, wrapper.children[index]);
       this.addEventListenerToWrapper(this.element)
       this.afterRender()
     }

--- a/src/ts/component/view/_view.ts
+++ b/src/ts/component/view/_view.ts
@@ -5,6 +5,12 @@ export default class View {
     this.element = document.createElement('div')
   }
 
+  // get data from controller to render itself
+  getID():string {
+    return ''
+  }
+  getData():any {}
+
   /*
 
     event handling

--- a/src/ts/component/view/_view.ts
+++ b/src/ts/component/view/_view.ts
@@ -10,6 +10,7 @@ export default class View {
     return ''
   }
   getData():any {}
+  getRenderData():any {}
 
   /*
 

--- a/src/ts/component/view/_view.ts
+++ b/src/ts/component/view/_view.ts
@@ -43,8 +43,11 @@ export default class View {
       // find out the target
       const target: HTMLElement = <HTMLElement>event.target
 
-      // get form data and convert to an object
-      const formDataObject = Object.fromEntries((new FormData(<HTMLFormElement>target)).entries())
+      // get form data
+      const formData = new FormData(<HTMLFormElement>target)
+
+      // convert form data to an object
+      const formDataObject = Object.fromEntries(formData.entries())
 
       // call the action with form data
       this.callAction(target.dataset.submitAction, formDataObject)

--- a/src/ts/component/view/column.ts
+++ b/src/ts/component/view/column.ts
@@ -1,6 +1,11 @@
 import ColumnData from '../../type/column'
 import View from './_view'
 
+export type ColumnRenderData = {
+  nNote: number,
+  formVisible: boolean
+}
+
 export default class ColumnView extends View {
   constructor() {
     super()
@@ -8,21 +13,24 @@ export default class ColumnView extends View {
 
   addNote() {}
 
+  toggleForm() {}
+
   removeSelf() {}
 
   toHtmlString() {
     const id = this.getID()
-    const { title, nNote }: ColumnData = this.getData()
+    const { title }: ColumnData = this.getData()
+    const { nNote, formVisible }: ColumnRenderData = this.getRenderData()
 
     return `
       <div id="${id}" class="column">
         <div class="d-flex flex-center mb-2">
           <span class="badge">${nNote}</span>
           <strong class="ml-2 mr-auto">${title}</strong>
-          <button>+</button>
+          <button data-click-action="toggleForm">+</button>
           <button data-click-action="removeSelf">×</button>
         </div>
-        <form class="mb-2" data-submit-action="addNote">
+        <form class="mb-2 ${formVisible ? '' : 'd-none'}" data-submit-action="addNote">
           <textarea name="title" class="fix-horizontal"></textarea>
           <div class="d-flex mt-2">
             <button type="submit" class="form-component flex-1 mr-1 bg-green white">Add</button>

--- a/src/ts/component/view/column.ts
+++ b/src/ts/component/view/column.ts
@@ -2,14 +2,8 @@ import ColumnData from '../../type/column'
 import View from './_view'
 
 export default class ColumnView extends View {
-  private id: String
-  private columnData: ColumnData
-
-  constructor({ id, columnData }: { id: String, columnData: ColumnData }) {
+  constructor() {
     super()
-    this.id = id
-    this.columnData = columnData
-    this.render()
   }
 
   addNote() {}
@@ -17,10 +11,14 @@ export default class ColumnView extends View {
   removeSelf() {}
 
   toHtmlString() {
+    const id = this.getID()
+    const { title }: ColumnData = this.getData()
+
     return `
-      <div id="${this.id}" class="column">
-        <div class="d-flex mb-2">
-          <strong class="mr-auto my-auto">${this.columnData.title}</strong>
+      <div id="${id}" class="column">
+        <div class="d-flex flex-center mb-2">
+          <span class="badge">7</span>
+          <strong class="ml-2 mr-auto">${title}</strong>
           <button>+</button>
           <button data-click-action="removeSelf">×</button>
         </div>

--- a/src/ts/component/view/column.ts
+++ b/src/ts/component/view/column.ts
@@ -12,12 +12,12 @@ export default class ColumnView extends View {
 
   toHtmlString() {
     const id = this.getID()
-    const { title }: ColumnData = this.getData()
+    const { title, nNote }: ColumnData = this.getData()
 
     return `
       <div id="${id}" class="column">
         <div class="d-flex flex-center mb-2">
-          <span class="badge">7</span>
+          <span class="badge">${nNote}</span>
           <strong class="ml-2 mr-auto">${title}</strong>
           <button>+</button>
           <button data-click-action="removeSelf">×</button>

--- a/src/ts/component/view/kanban.ts
+++ b/src/ts/component/view/kanban.ts
@@ -1,22 +1,17 @@
-import KanbanData from '../../type/kanban'
 import View from './_view'
 
 export default class KanbanView extends View {
-  private id: String
-  private kanbanData: KanbanData
-
-  constructor({ id, kanbanData }: { id: String, kanbanData: KanbanData }) {
+  constructor() {
     super()
-    this.id = id
-    this.kanbanData = kanbanData
-    this.render()
   }
 
   addColumn() {}
 
   toHtmlString() {
+    const id = this.getID()
+
     return `
-      <div id="${this.id}" class="kanban">
+      <div id="${id}" class="kanban">
         <div class="children-wrapper" data-wrapper-type="column">
           <!-- columns here -->
         </div>

--- a/src/ts/component/view/note.ts
+++ b/src/ts/component/view/note.ts
@@ -2,14 +2,8 @@ import NoteData from '../../type/note'
 import View from './_view'
 
 export default class NoteView extends View {
-  private id: String
-  private noteData: NoteData
-
-  constructor({ id, noteData }: { id: String, noteData: NoteData }) {
+  constructor() {
     super()
-    this.id = id
-    this.noteData = noteData
-    this.render()
   }
 
   editNote() {}
@@ -17,10 +11,13 @@ export default class NoteView extends View {
   removeSelf() {}
 
   toHtmlString() {
+    const id = this.getID()
+    const { title }: NoteData = this.getData()
+
     return `
-      <div id="${this.id}" class="note" role="button" data-action="editNote">
+      <div id="${id}" class="note" role="button" data-action="editNote">
         <div class="d-flex mb-2">
-          <strong class="mr-auto my-auto">${this.noteData.title}</strong>
+          <strong class="mr-auto my-auto">${title}</strong>
           <button data-click-action="removeSelf">×</button>
         </div>
         <p class="text-small my-1 gray">Added by</p>

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -4,7 +4,7 @@ import ColumnController from './component/controller/column'
 import KanbanController from './component/controller/kanban'
 import { findOne } from './util/index'
 
-const kanban = new KanbanController({ id: 'kanban', kanbanData: {} })
+const kanbanController = new KanbanController({ id: 'kanban', kanbanData: {} })
 
 window.addEventListener('DOMContentLoaded', (event) => {
   // fetch data
@@ -27,15 +27,12 @@ window.addEventListener('DOMContentLoaded', (event) => {
   }
 
   kanbanData.forEach(({ title, notes }) => {
-    const columnController = kanban.addColumnWithData({ title })
-    // const column = new ColumnController({ id: '', columnData: { title } })
-    // notes.forEach(({ title, subtasks }) => {
-    //   const note = new NoteController({ id: '', taskData: { title } })
-    //   initAndAddTasks(note, subtasks)
-    //   column.addNote(note)
-    // })
+    const columnController = kanbanController.addColumn({ title })
+    notes.forEach(({ title, subtasks }) => {
+      const noteController = columnController.addNote({ title })
+    })
     // kanban.addColumn(column)
   })
 
-  kanban.setWrapper(findOne('#kanban_box'))
+  kanbanController.setWrapper(findOne('#kanban_box'))
 })

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -27,7 +27,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
   }
 
   kanbanData.forEach(({ title, notes }) => {
-    const columnController = kanbanController.addColumn({ title })
+    const columnController = kanbanController.addColumn({ title, nNote: 0 })
     notes.forEach(({ title, subtasks }) => {
       const noteController = columnController.addNote({ title })
     })

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -27,7 +27,7 @@ window.addEventListener('DOMContentLoaded', (event) => {
   }
 
   kanbanData.forEach(({ title, notes }) => {
-    const columnController = kanbanController.addColumn({ title, nNote: 0 })
+    const columnController = kanbanController.addColumn({ title })
     notes.forEach(({ title, subtasks }) => {
       const noteController = columnController.addNote({ title })
     })

--- a/src/ts/type/column.ts
+++ b/src/ts/type/column.ts
@@ -1,6 +1,5 @@
 type ColumnData = {
-  title: string,
-  nNote: number // number of notes
+  title: string
 }
 
 export default ColumnData

--- a/src/ts/type/column.ts
+++ b/src/ts/type/column.ts
@@ -1,5 +1,6 @@
 type ColumnData = {
-  title: String
+  title: String,
+  nNote: number // number of notes
 }
 
 export default ColumnData

--- a/src/ts/type/column.ts
+++ b/src/ts/type/column.ts
@@ -1,5 +1,5 @@
 type ColumnData = {
-  title: String,
+  title: string,
   nNote: number // number of notes
 }
 

--- a/src/ts/type/note.ts
+++ b/src/ts/type/note.ts
@@ -1,5 +1,5 @@
 type NoteData = {
-  title: String
+  title: string
 }
 
 export default NoteData

--- a/src/ts/type/task.ts
+++ b/src/ts/type/task.ts
@@ -1,5 +1,5 @@
 type TaskData = {
-  title: String
+  title: string
 }
 
 export default TaskData


### PR DESCRIPTION
## 구조 개선
- View와 그에 상속되는 클래스에서 data 제거
  - view와 model을 완전히 분리
  - data가 변경될 때 controller에 의해 view의 render() 호출
  - render()에서 필요한 데이터를 controller에 요청
- Column 내 Note의 갯수 등, 렌더링 과정에서만 필요한 데이터를 renderData로 분리

## 기능 개선
- Column 추가/수정/삭제 시 Column 간 순서 유지
- 새 Note 추가 영역 숨김/표시
- Column 내 Note 갯수 표시
- Column 내 Note 추가 시 맨 위에 노출됨

![image](https://user-images.githubusercontent.com/10149370/106448818-9de0f500-64c6-11eb-9470-5ec7a21bd5c1.png)
