### PR TITLE
Step 6 - Bind methods with option, and show modal

### DIFF
--- a/src/scss/_form.scss
+++ b/src/scss/_form.scss
@@ -30,3 +30,8 @@ textarea.fix-horizontal {
   resize: vertical;
   width: 100%;
 }
+
+label {
+  margin-bottom: 0.5em;
+  display: inline-block;
+}

--- a/src/scss/_modal.scss
+++ b/src/scss/_modal.scss
@@ -1,0 +1,35 @@
+.modal-box {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  background-color: rgba(0, 0, 0, .32);
+  padding: 1.5em 1.5em 6em 1.5em;
+
+  .modal {
+    margin: auto;
+    background-color: $color-bright;
+    border-radius: 0.5em;
+    border: 1px solid $color-white;
+    overflow: hidden;
+    box-shadow: 0 3px 6px rgba(72, 72, 96, .14), 0 3px 6px rgba(0, 0, 0, .27);
+
+    .modal-head,
+    .modal-body {
+      padding: 1em;
+    }
+
+    .modal-head {
+      display: flex;
+      align-items: center;
+      background-color: $color-light;
+      border-bottom: 1px solid $color-lightgray;
+    }
+
+    // .modal-body {}
+  }
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -17,6 +17,7 @@
 @import 'image';
 @import 'list';
 @import 'kanban';
+@import 'modal';
 @import 'nav';
 
 @import 'color';

--- a/src/ts/component/controller/_controller.ts
+++ b/src/ts/component/controller/_controller.ts
@@ -1,5 +1,10 @@
 import View from "../view/_view"
 
+interface MethodBindingOption {
+  methodName: string,
+  bindTarget: Controller,
+}
+
 export default class Controller {
   private updateListeners: Array<Function>
   private deleteListeners: Array<Function>
@@ -35,9 +40,21 @@ export default class Controller {
     this.view.render(wrapper, index)
   }
 
-  bindMethods(methods: Array<string>) {
-    methods.forEach(method => {
-      (this.view as any)[method] = (this as any)[method].bind(this)
+  bindMethods(bindingOptions: Array<MethodBindingOption | string>) {
+    bindingOptions.forEach(bindingOption => {
+
+      // set name of method to bind, and binding target
+      let methodName, bindTarget
+      if (typeof bindingOption === 'string') {
+        methodName = bindingOption
+        bindTarget = this
+      } else {
+        methodName = bindingOption.methodName
+        bindTarget = bindingOption.bindTarget
+      }
+
+      // bind method
+      (this.view as any)[methodName] = (bindTarget as any)[methodName].bind(bindTarget)
     })
   }
 }

--- a/src/ts/component/controller/column.ts
+++ b/src/ts/component/controller/column.ts
@@ -3,6 +3,7 @@ import Controller from './_controller'
 import NoteController from './note'
 import ColumnView, { ColumnRenderData } from '../view/column'
 import NoteData from '../../type/note'
+import ModalController from './modal'
 
 export default class ColumnController extends Controller {
   private columnData: ColumnData
@@ -21,6 +22,7 @@ export default class ColumnController extends Controller {
       'addNote',
       'toggleForm',
       'removeSelf',
+      'showEditModal',
     ])
     this.view.render()
   }
@@ -73,5 +75,35 @@ export default class ColumnController extends Controller {
   toggleForm() {
     this.renderData.formVisible = !this.renderData.formVisible
     this.view.render()
+  }
+
+  editColumn({ columnName }: { columnName: string }) {
+    columnName = columnName.trim()
+
+    // handle exception: invalid or same name
+    if (!columnName || columnName === this.columnData.title) return
+
+    // update column's name
+    this.columnData.title = columnName
+    this.view.render()
+  }
+
+  showEditModal() {
+    new ModalController({
+      id: '',
+      renderData: {
+        title: 'Edit Column',
+        htmlString: `
+          <form data-submit-action="editColumn">
+            <div class="mb-3">
+              <label for="modal-body-input">Column name</label>
+              <input type="text" name="columnName" id="modal-body-input" class="w-100" placeholder="${this.columnData.title}">
+            </div>
+            <button type="submit" class="form-component bg-green white">Update</button>
+          </form>
+        `
+      },
+      parentController: this
+    })
   }
 }

--- a/src/ts/component/controller/modal.ts
+++ b/src/ts/component/controller/modal.ts
@@ -1,0 +1,32 @@
+import Controller from './_controller'
+import ModalView, { ModalRenderData } from '../view/modal'
+
+export default class ModalController extends Controller {
+  private renderData: ModalRenderData
+
+  constructor({ id, renderData, parentController }: { id: string, renderData: ModalRenderData, parentController: Controller }) {
+    super()
+    this.id = id
+    this.renderData = renderData
+    this.view = new ModalView()
+    this.bindMethods([
+      'getID',
+      'getRenderData',
+      'closeModal',
+      { methodName: 'editColumn', bindTarget: parentController }
+    ])
+    this.setWrapper(document.body)
+    this.view.render()
+  }
+
+  getRenderData() {
+    return this.renderData
+  }
+
+  closeModal() {
+    // remove view
+    this.view.remove()
+
+    this.notifyDelete()
+  }
+}

--- a/src/ts/component/view/_view.ts
+++ b/src/ts/component/view/_view.ts
@@ -25,7 +25,7 @@ export default class View {
 
       // find out the target
       let target: HTMLElement = <HTMLElement>event.target
-      while (!target.dataset.clickAction) {
+      while (target.dataset.clickAction === undefined) {
         // if no action, do nothing
         if (target === this.element) return
         // else, go to parents

--- a/src/ts/component/view/_view.ts
+++ b/src/ts/component/view/_view.ts
@@ -1,3 +1,48 @@
+// submit event handler
+function submitEventListener(event: Event) {
+  event.stopPropagation()
+  event.preventDefault()
+
+  // find out the target
+  const target: HTMLElement = <HTMLElement>event.target
+
+  // get form data
+  const formData = new FormData(<HTMLFormElement>target)
+
+  // convert form data to an object
+  const formDataObject = Object.fromEntries(formData.entries())
+
+  // call the action with form data
+  this.callAction(target.dataset.submitAction, formDataObject)
+}
+
+// common event handler
+function commonEventListener(event: Event, actionName: string) {
+  event.stopPropagation()
+
+  // find out the target
+  let target: HTMLElement = <HTMLElement>event.target
+  while (target.dataset[actionName] === undefined) {
+    // if no action, do nothing
+    if (target === this.element) return
+    // else, go to parents
+    target = target.parentElement
+  }
+
+  // call the action
+  this.callAction(target.dataset[actionName])
+}
+
+// click event handler
+function clickEventListener(event: Event) {
+  return commonEventListener.bind(this)(event, 'clickAction')
+}
+
+// double-click event handler
+function dblclickEventListener(event: Event) {
+  return commonEventListener.bind(this)(event, 'dblclickAction')
+}
+
 export default class View {
   protected element: HTMLElement // temporary root
 
@@ -20,39 +65,13 @@ export default class View {
 
   addEventListenerToWrapper(wrapper: HTMLElement) {
     // click event
-    wrapper.addEventListener('click', event => {
-      event.stopPropagation()
+    wrapper.addEventListener('click', clickEventListener.bind(this))
 
-      // find out the target
-      let target: HTMLElement = <HTMLElement>event.target
-      while (target.dataset.clickAction === undefined) {
-        // if no action, do nothing
-        if (target === this.element) return
-        // else, go to parents
-        target = target.parentElement
-      }
-
-      // call the action
-      this.callAction(target.dataset.clickAction)
-    })
+    // double-click event
+    wrapper.addEventListener('dblclick', dblclickEventListener.bind(this))
 
     // submit event
-    wrapper.addEventListener('submit', event => {
-      event.stopPropagation()
-      event.preventDefault()
-
-      // find out the target
-      const target: HTMLElement = <HTMLElement>event.target
-
-      // get form data
-      const formData = new FormData(<HTMLFormElement>target)
-
-      // convert form data to an object
-      const formDataObject = Object.fromEntries(formData.entries())
-
-      // call the action with form data
-      this.callAction(target.dataset.submitAction, formDataObject)
-    })
+    wrapper.addEventListener('submit', submitEventListener.bind(this))
   }
 
   callAction(action: string, arg?: any) {

--- a/src/ts/component/view/column.ts
+++ b/src/ts/component/view/column.ts
@@ -26,7 +26,7 @@ export default class ColumnView extends View {
       <div id="${id}" class="column">
         <div class="d-flex flex-center mb-2">
           <span class="badge">${nNote}</span>
-          <strong class="ml-2 mr-auto">${title}</strong>
+          <strong class="ml-2 mr-auto" role="button" data-click-action="showEditModal">${title}</strong>
           <button data-click-action="toggleForm">+</button>
           <button data-click-action="removeSelf">×</button>
         </div>

--- a/src/ts/component/view/column.ts
+++ b/src/ts/component/view/column.ts
@@ -11,12 +11,6 @@ export default class ColumnView extends View {
     super()
   }
 
-  addNote() {}
-
-  toggleForm() {}
-
-  removeSelf() {}
-
   toHtmlString() {
     const id = this.getID()
     const { title }: ColumnData = this.getData()

--- a/src/ts/component/view/column.ts
+++ b/src/ts/component/view/column.ts
@@ -20,7 +20,7 @@ export default class ColumnView extends View {
       <div id="${id}" class="column">
         <div class="d-flex flex-center mb-2">
           <span class="badge">${nNote}</span>
-          <strong class="flex-1 ml-2 mr-auto" role="button" data-click-action="showEditModal">${title}</strong>
+          <strong class="flex-1 ml-2 mr-auto" role="button" data-dblclick-action="showEditModal">${title}</strong>
           <button data-click-action="toggleForm">+</button>
           <button data-click-action="removeSelf">×</button>
         </div>

--- a/src/ts/component/view/column.ts
+++ b/src/ts/component/view/column.ts
@@ -20,7 +20,7 @@ export default class ColumnView extends View {
       <div id="${id}" class="column">
         <div class="d-flex flex-center mb-2">
           <span class="badge">${nNote}</span>
-          <strong class="ml-2 mr-auto" role="button" data-click-action="showEditModal">${title}</strong>
+          <strong class="flex-1 ml-2 mr-auto" role="button" data-click-action="showEditModal">${title}</strong>
           <button data-click-action="toggleForm">+</button>
           <button data-click-action="removeSelf">×</button>
         </div>

--- a/src/ts/component/view/kanban.ts
+++ b/src/ts/component/view/kanban.ts
@@ -5,8 +5,6 @@ export default class KanbanView extends View {
     super()
   }
 
-  addColumn() {}
-
   toHtmlString() {
     const id = this.getID()
 

--- a/src/ts/component/view/modal.ts
+++ b/src/ts/component/view/modal.ts
@@ -1,0 +1,31 @@
+import View from './_view'
+
+export type ModalRenderData = {
+  title: string,
+  htmlString: string
+}
+
+export default class ModalView extends View {
+  constructor() {
+    super()
+  }
+
+  toHtmlString() {
+    const id = this.getID()
+    const { title, htmlString }: ModalRenderData = this.getRenderData()
+
+    return `
+      <div id="${id}" class="modal-box" data-click-action="closeModal">
+        <div class="modal" data-click-action="">
+          <div class="modal-head">
+            <strong>${title}</strong>
+            <button data-click-action="closeModal">×</button>
+          </div>
+          <div class="modal-body">
+            ${htmlString}
+          </div>
+        </div>
+      </div>
+    `
+  }
+}

--- a/src/ts/component/view/note.ts
+++ b/src/ts/component/view/note.ts
@@ -6,10 +6,6 @@ export default class NoteView extends View {
     super()
   }
 
-  editNote() {}
-
-  removeSelf() {}
-
   toHtmlString() {
     const id = this.getID()
     const { title }: NoteData = this.getData()


### PR DESCRIPTION
## 구조 개선
- View의 이벤트 핸들러 코드 분리
- Controller.bindMethods() 확장
  - event에 따른 action이 다른 Controller의 method를 호출할 수 있음
  - view에서 controller에 bind되기 위한 빈 함수를 선언하지 않아도 됨

## 기능 개선
- View에서 더블클릭 이벤트 지원
- Modal 작성
  - 특정 Controller와 View에 종속되어 동적으로 생성/삭제
  - Modal을 호출(생성)한 Controller에서 Modal의 내용 설정
- Column 이름 더블클릭하여 Modal 표시
  - Modal을 통해 Column 이름 변경 가능

![image](https://user-images.githubusercontent.com/10149370/106587050-7bb1aa80-658c-11eb-8178-810b2e3588d4.png)
